### PR TITLE
fix shadowed names

### DIFF
--- a/hw01/src/HW01.hs
+++ b/hw01/src/HW01.hs
@@ -21,6 +21,7 @@ doubleEveryOther nums = reverse (doubleEveryOtherAux (reverse (nums)))
 
 doubleEveryOtherAux :: [Integer] -> [Integer]
 doubleEveryOtherAux [] = []
+-- CM: shadowed names need to be fixed.
 doubleEveryOtherAux (head:[]) = [head]
 doubleEveryOtherAux (head:next:tail) = head : next * 2 : doubleEveryOtherAux(tail)
 


### PR DESCRIPTION
Joe, your build errors are because you are shadowing names `head` and `tail` that are already defined in the Haskell Prelude. If you look at hw01.cabal, you will see the `-Wall` flag is passed to `ghc-optiond`. This means that all warnings (shadowed name, in this case) become errors. Just rename these so that they don't conflict.