### PR TITLE
fix integer concatenation and syntax cleanup

### DIFF
--- a/hw01/src/HW01.hs
+++ b/hw01/src/HW01.hs
@@ -30,6 +30,7 @@ sumDigits nums = foldl (+) 0 (toDigits(concatIntegerLists (nums)))
 -- took this function from:
 -- https://stackoverflow.com/questions/1918486/convert-list-of-integers-into-one-int-like-concat-in-haskell
 -- is it generally OK to take helper functions like these and cite them? I'm supposing yes?
+-- CM: sure, but see comment in pull request
 concatIntegerLists :: [Integer] -> Integer
 concatIntegerLists = foldl addDigit 0
   where addDigit num d = 10 * num + d


### PR DESCRIPTION
Bugfix: `concatIntegerLists` makes an assumption which is not necessarily true for your use case. Consider the following: `validate 7710570515120986`. You can apply each function in turn and examine the results.

Useful tip: in `ghci`, the label `it` always has the value of the last expression. E.g.,

    > 3 + 5
    8
    > it
    8

Cleanup: you are using too many parentheses (very natural when first starting in Haskell). Be aware that function application binds more tightly than almost anything, and that you only need parentheses to show precedence, not to pass arguments.